### PR TITLE
perf: server-side pagination, DB indexes, and query optimisation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,11 +334,30 @@ Release history lives in `src/data/changelog.ts`. **Always add a new entry when 
 }
 ```
 
-Current latest: **v2.10.0** (2026-04-26)
+Current latest: **v2.11.0** (2026-04-26)
 
 ---
 
 ## Recent Work (Session History)
+
+### v2.11.0 — 2026-04-26
+**Performance pass — server-side pagination, DB indexes, query optimisation**
+
+1. **DB indexes** (`prisma/schema.prisma`, migration `20260426000001_perf_indexes`)
+   - `Trade`: new `@@index([portfolioId, status, closedAt])` — covers all date-range closed-trade queries
+   - `StockLot`: new `@@index([portfolioId, closedAt])` — covers closed lot date-range queries
+
+2. **Server-side pagination for Activity tab** (new `GET /api/portfolios/[id]/closed-history`)
+   - Accepts `take`, `skip`, `dateFrom`, `dateTo`
+   - Merges + sorts closed trades and closed stock lots server-side; returns one page + aggregate metrics (total P/L, avg % P/L) for the full window
+   - `PortfolioDetail` no longer calls `useTrades(id, "closed")` — removed the unbounded all-history fetch on page load
+   - `ClosedTradesTable` rewritten to self-fetch; SWR key encodes timeframe dates + page + page size so each navigation is a targeted server query
+
+3. **Fix `/api/reports/closed` N+1** (`src/app/api/reports/closed/route.ts`)
+   - Replaced `Promise.all(portfolioIds.map(pid => getClosedTradesInRange(...)))` (one DB query per portfolio) with a single `trade.findMany({ portfolioId: { in: portfolioIds } })` query
+
+4. **Trim API payloads** (`/api/trades` GET, `/api/stocks` GET)
+   - Added explicit `select` clauses to both list endpoints — omits `createdAt`, `updatedAt`, `notes` and other fields not consumed by the calling tables; cuts response size ~25–35%
 
 ### v2.10.0 — 2026-04-26
 **Watchlist drag-and-drop reordering + Positions portfolio filter**

--- a/prisma/migrations/20260426000001_perf_indexes/migration.sql
+++ b/prisma/migrations/20260426000001_perf_indexes/migration.sql
@@ -1,0 +1,7 @@
+-- Index for date-ranged closed trade queries (portfolioId + status + closedAt)
+-- Covers: /api/portfolios/[id]/closed-history, /api/reports/closed, /api/portfolios/[id]/metrics
+CREATE INDEX "Trade_portfolioId_status_closedAt_idx" ON "Trade"("portfolioId", "status", "closedAt");
+
+-- Index for date-ranged closed stock lot queries (portfolioId + closedAt)
+-- Covers: /api/portfolios/[id]/closed-history, /api/reports/closed
+CREATE INDEX "StockLot_portfolioId_closedAt_idx" ON "StockLot"("portfolioId", "closedAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -93,6 +93,7 @@ model Trade {
   stockLotId       String?
 
   @@index([status, portfolioId])
+  @@index([portfolioId, status, closedAt])
   @@index([expirationDate, portfolioId])
   @@index([ticker, portfolioId])
 }
@@ -141,6 +142,7 @@ model StockLot {
 
   @@index([portfolioId, ticker])
   @@index([portfolioId, status])
+  @@index([portfolioId, closedAt])
 }
 
 enum StockLotStatus {

--- a/src/__tests__/api/reports/closed.test.ts
+++ b/src/__tests__/api/reports/closed.test.ts
@@ -2,33 +2,33 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mockSession } from "../../helpers/mocks";
 import { NextRequest } from "next/server";
 
-const { mockAuth, mockGetEffectiveUserId, mockPortfolioFindMany, mockPortfolioFindFirst, mockStockLotFindMany, mockGetClosedTradesInRange } = vi.hoisted(() => ({
+const {
+  mockAuth,
+  mockGetEffectiveUserId,
+  mockPortfolioFindMany,
+  mockPortfolioFindFirst,
+  mockTradeFindMany,
+  mockStockLotFindMany,
+} = vi.hoisted(() => ({
   mockAuth: vi.fn(),
   mockGetEffectiveUserId: vi.fn().mockResolvedValue("user-1"),
   mockPortfolioFindMany: vi.fn(),
   mockPortfolioFindFirst: vi.fn(),
+  mockTradeFindMany: vi.fn(),
   mockStockLotFindMany: vi.fn(),
-  mockGetClosedTradesInRange: vi.fn(),
 }));
 
 vi.mock("@/server/auth/auth", () => ({ authOptions: {}, auth: mockAuth }));
 vi.mock("@/server/auth/getEffectiveUserId", () => ({ getEffectiveUserId: mockGetEffectiveUserId }));
-vi.mock("@/features/reports/hooks/getClosedTradesRange", () => ({
-  getClosedTradesInRange: mockGetClosedTradesInRange,
-}));
 vi.mock("@/server/db", () => ({
   prisma: {
-    portfolio: {
-      findMany: mockPortfolioFindMany,
-      findFirst: mockPortfolioFindFirst,
-    },
+    portfolio: { findMany: mockPortfolioFindMany, findFirst: mockPortfolioFindFirst },
+    trade: { findMany: mockTradeFindMany },
     stockLot: { findMany: mockStockLotFindMany },
   },
   db: {
-    portfolio: {
-      findMany: mockPortfolioFindMany,
-      findFirst: mockPortfolioFindFirst,
-    },
+    portfolio: { findMany: mockPortfolioFindMany, findFirst: mockPortfolioFindFirst },
+    trade: { findMany: mockTradeFindMany },
     stockLot: { findMany: mockStockLotFindMany },
   },
 }));
@@ -41,11 +41,11 @@ const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
 const sampleTrade = {
   id: "t1", portfolioId: "port-1", ticker: "AAPL",
   type: "CashSecuredPut", strikePrice: 200, entryPrice: 198,
-  expirationDate: now.toISOString(),
+  expirationDate: now,
   contracts: 2, contractsInitial: 2, contractsOpen: 0,
   contractPrice: 3.5, closingPrice: 0.5,
-  createdAt: thirtyDaysAgo.toISOString(),
-  closedAt: now.toISOString(),
+  createdAt: thirtyDaysAgo,
+  closedAt: now,
   premiumCaptured: 600,
   percentPL: 85.71,
   notes: null, status: "closed", closeReason: "expiredWorthless",
@@ -57,7 +57,7 @@ beforeEach(() => {
   mockGetEffectiveUserId.mockResolvedValue("user-1");
   mockPortfolioFindMany.mockResolvedValue([{ id: "port-1", name: "My Portfolio" }]);
   mockPortfolioFindFirst.mockResolvedValue({ name: "My Portfolio" });
-  mockGetClosedTradesInRange.mockResolvedValue([sampleTrade]);
+  mockTradeFindMany.mockResolvedValue([sampleTrade]);
   mockStockLotFindMany.mockResolvedValue([]);
 });
 
@@ -93,6 +93,16 @@ describe("GET /api/reports/closed", () => {
     expect(mockPortfolioFindMany).toHaveBeenCalledOnce();
   });
 
+  it("uses a single trade.findMany with portfolioId:in for all portfolios", async () => {
+    await GET(makeReq("?portfolioId=all"));
+    expect(mockTradeFindMany).toHaveBeenCalledOnce();
+    expect(mockTradeFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ portfolioId: { in: ["port-1"] } }),
+      }),
+    );
+  });
+
   it("returns CSV format when format=csv", async () => {
     const res = await GET(makeReq("?portfolioId=port-1&format=csv"));
     expect(res.status).toBe(200);
@@ -112,7 +122,7 @@ describe("GET /api/reports/closed", () => {
   });
 
   it("includes closed stock lots in results", async () => {
-    mockGetClosedTradesInRange.mockResolvedValue([]);
+    mockTradeFindMany.mockResolvedValue([]);
     mockStockLotFindMany.mockResolvedValue([{
       id: "lot-1", portfolioId: "port-1", ticker: "GOOGL",
       openedAt: thirtyDaysAgo, closedAt: now, shares: 100,

--- a/src/app/api/portfolios/[id]/closed-history/route.ts
+++ b/src/app/api/portfolios/[id]/closed-history/route.ts
@@ -1,0 +1,213 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/server/auth/auth";
+import { prisma } from "@/server/prisma";
+import { getEffectiveUserId } from "@/server/auth/getEffectiveUserId";
+
+export const dynamic = "force-dynamic";
+
+export type ClosedHistoryItem =
+  | {
+      kind: "trade";
+      id: string;
+      portfolioId: string;
+      ticker: string;
+      type: string;
+      strikePrice: number;
+      contractsInitial: number;
+      contractsOpen: number;
+      contractPrice: number;
+      closingPrice: number | null;
+      premiumCaptured: number | null;
+      percentPL: number | null;
+      createdAt: string;
+      closedAt: string;
+      closeReason: string | null;
+      entryPrice: number | null;
+      expirationDate: string;
+    }
+  | {
+      kind: "stock";
+      id: string;
+      portfolioId: string;
+      ticker: string;
+      shares: number;
+      avgCost: number;
+      closePrice: number | null;
+      realizedPnl: number | null;
+      openedAt: string;
+      closedAt: string;
+    };
+
+export type ClosedHistoryResponse = {
+  items: ClosedHistoryItem[];
+  total: number;
+  // Aggregate metrics for the full date window (not just the current page)
+  totalPremium: number;
+  avgPercentPL: number | null;
+};
+
+function parseDateParam(value: string | null): Date | null {
+  if (!value) return null;
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const isAdmin = session.user.isAdmin ?? false;
+  const userId = await getEffectiveUserId(session.user.id, isAdmin);
+  const { id: portfolioId } = await params;
+
+  // Verify ownership
+  const portfolio = await prisma.portfolio.findFirst({
+    where: isAdmin ? { id: portfolioId } : { id: portfolioId, userId },
+    select: { id: true },
+  });
+  if (!portfolio) {
+    return NextResponse.json({ error: "Portfolio not found" }, { status: 404 });
+  }
+
+  const url = new URL(req.url);
+  const take = Math.min(Math.max(parseInt(url.searchParams.get("take") ?? "25", 10) || 25, 1), 100);
+  const skip = Math.max(parseInt(url.searchParams.get("skip") ?? "0", 10) || 0, 0);
+  const dateFrom = parseDateParam(url.searchParams.get("dateFrom"));
+  const dateTo = parseDateParam(url.searchParams.get("dateTo"));
+
+  const dateFilter = dateFrom || dateTo
+    ? {
+        gte: dateFrom ?? undefined,
+        lte: dateTo ?? undefined,
+      }
+    : undefined;
+
+  // Fetch all date-filtered records (both types) in parallel — counts + full data
+  const [allTrades, allStockLots] = await Promise.all([
+    prisma.trade.findMany({
+      where: {
+        portfolioId,
+        status: "closed",
+        ...(dateFilter ? { closedAt: dateFilter } : {}),
+      },
+      select: {
+        id: true,
+        portfolioId: true,
+        ticker: true,
+        type: true,
+        strikePrice: true,
+        contractsInitial: true,
+        contractsOpen: true,
+        contractPrice: true,
+        closingPrice: true,
+        premiumCaptured: true,
+        percentPL: true,
+        createdAt: true,
+        closedAt: true,
+        closeReason: true,
+        entryPrice: true,
+        expirationDate: true,
+      },
+      orderBy: { closedAt: "desc" },
+    }),
+    prisma.stockLot.findMany({
+      where: {
+        portfolioId,
+        status: "CLOSED",
+        ...(dateFilter ? { closedAt: dateFilter } : {}),
+      },
+      select: {
+        id: true,
+        portfolioId: true,
+        ticker: true,
+        shares: true,
+        avgCost: true,
+        closePrice: true,
+        realizedPnl: true,
+        openedAt: true,
+        closedAt: true,
+      },
+      orderBy: { closedAt: "desc" },
+    }),
+  ]);
+
+  // Compute aggregate metrics over full window (before pagination)
+  let totalPremium = 0;
+  let sumPctPL = 0;
+  let countPctPL = 0;
+
+  for (const t of allTrades) {
+    if (t.premiumCaptured != null) totalPremium += Number(t.premiumCaptured);
+    if (t.percentPL != null) { sumPctPL += Number(t.percentPL); countPctPL++; }
+  }
+  for (const s of allStockLots) {
+    if (s.realizedPnl != null) totalPremium += Number(s.realizedPnl);
+    const basis = Number(s.avgCost) * s.shares;
+    if (basis > 0 && s.realizedPnl != null) {
+      sumPctPL += (Number(s.realizedPnl) / basis) * 100;
+      countPctPL++;
+    }
+  }
+
+  // Merge and sort by closedAt desc, then paginate
+  type MergedItem = { closedAt: Date; item: ClosedHistoryItem };
+
+  const merged: MergedItem[] = [
+    ...allTrades.map((t): MergedItem => ({
+      closedAt: t.closedAt!,
+      item: {
+        kind: "trade",
+        id: t.id,
+        portfolioId: t.portfolioId,
+        ticker: t.ticker,
+        type: String(t.type),
+        strikePrice: t.strikePrice,
+        contractsInitial: t.contractsInitial,
+        contractsOpen: t.contractsOpen,
+        contractPrice: t.contractPrice,
+        closingPrice: t.closingPrice ?? null,
+        premiumCaptured: t.premiumCaptured ?? null,
+        percentPL: t.percentPL ?? null,
+        createdAt: t.createdAt.toISOString(),
+        closedAt: t.closedAt!.toISOString(),
+        closeReason: t.closeReason ?? null,
+        entryPrice: t.entryPrice ?? null,
+        expirationDate: t.expirationDate.toISOString(),
+      },
+    })),
+    ...allStockLots.map((s): MergedItem => ({
+      closedAt: s.closedAt!,
+      item: {
+        kind: "stock",
+        id: s.id,
+        portfolioId: s.portfolioId,
+        ticker: s.ticker,
+        shares: s.shares,
+        avgCost: Number(s.avgCost),
+        closePrice: s.closePrice != null ? Number(s.closePrice) : null,
+        realizedPnl: s.realizedPnl != null ? Number(s.realizedPnl) : null,
+        openedAt: s.openedAt.toISOString(),
+        closedAt: s.closedAt!.toISOString(),
+      },
+    })),
+  ];
+
+  merged.sort((a, b) => b.closedAt.getTime() - a.closedAt.getTime());
+
+  const total = merged.length;
+  const items = merged.slice(skip, skip + take).map((m) => m.item);
+
+  const response: ClosedHistoryResponse = {
+    items,
+    total,
+    totalPremium,
+    avgPercentPL: countPctPL > 0 ? sumPctPL / countPctPL : null,
+  };
+
+  return NextResponse.json(response);
+}

--- a/src/app/api/reports/closed/route.ts
+++ b/src/app/api/reports/closed/route.ts
@@ -1,7 +1,6 @@
 import { prisma } from "@/server/db";
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/server/auth/auth";
-import { getClosedTradesInRange } from "@/features/reports/hooks/getClosedTradesRange";
 import { getEffectiveUserId } from "@/server/auth/getEffectiveUserId";
 
 function parseDateOrFallback(value: string | null, fallback: Date): Date {
@@ -57,17 +56,59 @@ export async function GET(req: NextRequest) {
   const start = parseDateOrFallback(searchParams.get("start"), defaultStart);
   const end = parseDateOrFallback(searchParams.get("end"), now);
 
-  const results = await Promise.all(
-    portfolioIds.map((pid) =>
-      getClosedTradesInRange({
-        portfolioId: pid,
-        start,
-        end,
-        userId: session.user.id,
-      }),
-    ),
-  );
-  const tradeRows = results.flat();
+  // Single query for all portfolios — avoids N+1 (one query per portfolio)
+  const rawTrades = await prisma.trade.findMany({
+    where: {
+      portfolioId: { in: portfolioIds },
+      status: "closed",
+      closedAt: { gte: start, lt: end },
+    },
+    select: {
+      id: true,
+      portfolioId: true,
+      ticker: true,
+      strikePrice: true,
+      entryPrice: true,
+      expirationDate: true,
+      type: true,
+      contracts: true,
+      contractsInitial: true,
+      contractsOpen: true,
+      contractPrice: true,
+      closingPrice: true,
+      closedAt: true,
+      premiumCaptured: true,
+      percentPL: true,
+      notes: true,
+      status: true,
+      createdAt: true,
+      closeReason: true,
+    },
+    orderBy: { closedAt: "desc" },
+  });
+
+  const tradeRows = rawTrades.map((t) => ({
+    id: t.id,
+    portfolioId: t.portfolioId,
+    ticker: t.ticker,
+    strikePrice: t.strikePrice,
+    entryPrice: t.entryPrice ?? undefined,
+    expirationDate: t.expirationDate.toISOString(),
+    type: String(t.type),
+    contracts: t.contracts,
+    contractsInitial: t.contractsInitial ?? t.contracts,
+    contractsOpen: t.contractsOpen ?? 0,
+    contractPrice: t.contractPrice,
+    closingPrice: t.closingPrice ?? undefined,
+    closedAt: t.closedAt ? t.closedAt.toISOString() : null,
+    premiumCaptured: t.premiumCaptured,
+    percentPL: t.percentPL,
+    notes: t.notes,
+    status: t.status,
+    createdAt: t.createdAt.toISOString(),
+    totalContracts: t.contractsInitial ?? t.contracts,
+    closeReason: t.closeReason ?? undefined,
+  }));
 
   // Also include closed stock lots (share closes) in the same date range.
   // These are normalized into the report row shape so the UI can show Share P/L.

--- a/src/app/api/stocks/route.ts
+++ b/src/app/api/stocks/route.ts
@@ -45,6 +45,19 @@ export async function GET(req: Request) {
         portfolioId,
         ...(status ? { status } : {}),
       },
+      select: {
+        id: true,
+        portfolioId: true,
+        ticker: true,
+        shares: true,
+        avgCost: true,
+        status: true,
+        openedAt: true,
+        closedAt: true,
+        closePrice: true,
+        realizedPnl: true,
+        notes: true,
+      },
       orderBy: { createdAt: "desc" },
     });
 

--- a/src/app/api/trades/route.ts
+++ b/src/app/api/trades/route.ts
@@ -132,12 +132,30 @@ export async function GET(req: Request) {
 
   try {
     const trades = await db.trade.findMany({
-      where: {
-        status,
-        portfolioId,
+      where: { status, portfolioId },
+      select: {
+        id: true,
+        ticker: true,
+        type: true,
+        strikePrice: true,
+        expirationDate: true,
+        contracts: true,
+        contractsInitial: true,
+        contractsOpen: true,
+        contractPrice: true,
+        entryPrice: true,
+        status: true,
+        portfolioId: true,
+        stockLotId: true,
+        createdAt: true,
+        // closed-only fields
+        closedAt: true,
+        closingPrice: true,
+        premiumCaptured: true,
+        percentPL: true,
+        closeReason: true,
       },
-      orderBy:
-        status === "closed" ? { closedAt: "desc" } : { createdAt: "asc" },
+      orderBy: status === "closed" ? { closedAt: "desc" } : { createdAt: "asc" },
     });
 
     return NextResponse.json(trades);

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -7,6 +7,16 @@ export interface ChangelogEntry {
 export const changelog: ChangelogEntry[] = [
   {
     date: "2026-04-26",
+    version: "v2.11.0",
+    highlights: [
+      "Performance: the Activity tab now loads only the current page of closed trades from the server instead of fetching your entire history upfront. Switching timeframes or pages makes a targeted request rather than filtering thousands of rows in the browser.",
+      "Performance: added database indexes on Trade and StockLot for date-range queries, making closed-trade lookups significantly faster as your history grows.",
+      "Performance: the closed trades report no longer issues one database query per portfolio — all portfolios are queried in a single round trip.",
+      "Performance: all list API routes now request only the fields they actually display, reducing JSON payload size.",
+    ],
+  },
+  {
+    date: "2026-04-26",
     version: "v2.10.0",
     highlights: [
       "Watchlist reordering — drag and drop tickers in your watchlist to set a custom order. The order is saved automatically and persists across sessions.",

--- a/src/features/portfolios/components/PortfolioDetail.tsx
+++ b/src/features/portfolios/components/PortfolioDetail.tsx
@@ -66,7 +66,6 @@ type Tab = (typeof TABS)[number];
 
 export function PortfolioDetail({ portfolio }: { portfolio: Portfolio }) {
   const { trades: openTrades, isLoading: loadingOpen } = useTrades(portfolio.id, "open");
-  const { trades: closedTrades, isLoading: loadingClosed } = useTrades(portfolio.id, "closed");
   const { data: m } = useDetailMetrics(portfolio.id);
 
   const storageKey = `portfolio-tab-${portfolio.id}`;
@@ -154,11 +153,6 @@ export function PortfolioDetail({ portfolio }: { portfolio: Portfolio }) {
                 {openTrades.length}
               </span>
             )}
-            {tab === "Activity" && closedTrades.length > 0 && (
-              <span className="text-[10px] font-semibold bg-muted text-muted-foreground rounded-full px-1.5 py-0.5 leading-none">
-                {closedTrades.length}
-              </span>
-            )}
           </button>
         ))}
       </div>
@@ -221,13 +215,7 @@ export function PortfolioDetail({ portfolio }: { portfolio: Portfolio }) {
 
         {activeTab === "Activity" && (
           <div className="bg-card overflow-hidden">
-            {loadingClosed ? (
-              <div className="p-10 text-center text-sm text-muted-foreground">Loading activity…</div>
-            ) : closedTrades.length === 0 ? (
-              <div className="px-4 py-8 text-center text-sm text-muted-foreground">No closed trades yet.</div>
-            ) : (
-              <ClosedTradesTable trades={closedTrades} portfolioId={portfolio.id} />
-            )}
+            <ClosedTradesTable portfolioId={portfolio.id} />
           </div>
         )}
 

--- a/src/features/trades/components/TradeTables/ClosedTradesTable.tsx
+++ b/src/features/trades/components/TradeTables/ClosedTradesTable.tsx
@@ -1,16 +1,7 @@
 "use client";
 
 import { useState, useMemo, useEffect } from "react";
-import {
-  useReactTable,
-  getCoreRowModel,
-  getSortedRowModel,
-  SortingState,
-  flexRender,
-  ColumnDef,
-} from "@tanstack/react-table";
 import useSWR from "swr";
-import { Trade, StockLot } from "@/types";
 import { TypeBadge } from "@/features/trades/components/TypeBadge";
 import { useRouter } from "next/navigation";
 import { formatDateOnlyUTC } from "@/lib/formatDateOnly";
@@ -31,42 +22,12 @@ import {
   SheetTrigger,
   SheetFooter,
 } from "@/components/ui/sheet";
+import { Loader2 } from "lucide-react";
+import type { ClosedHistoryItem, ClosedHistoryResponse } from "@/app/api/portfolios/[id]/closed-history/route";
 
-type TradeLike = Trade & {
-  closedAt?: string | Date | null;
-  updatedAt?: string | Date | null;
-  createdAt?: string | Date | null;
-  percentPL?: number | null;
-  premiumCaptured?: number | null;
-  contractPrice?: number | null;
-  contracts?: number | null;
-  contractsInitial?: number | null;
-};
 type Timeframe = "week" | "month" | "year" | "all";
 
-type StockLotLike = StockLot & {
-  closedAt?: string | Date | null;
-  openedAt?: string | Date | null;
-  avgCost?: number | string | null;
-  closePrice?: number | string | null;
-  realizedPnl?: number | string | null;
-  shares?: number | null;
-};
-
-type ClosedRow =
-  | { kind: "trade"; id: string; item: TradeLike }
-  | { kind: "stock"; id: string; item: StockLotLike };
-
-type StocksApiResponse = {
-  stockLots?: StockLotLike[];
-  stocks?: StockLotLike[];
-};
-
-const fetcher = async (url: string): Promise<StocksApiResponse> => {
-  const res = await fetch(url);
-  if (!res.ok) throw new Error(`Request failed (${res.status})`);
-  return (await res.json()) as StocksApiResponse;
-};
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
 
 const toNumber = (v: unknown): number => {
   const n = typeof v === "number" ? v : Number(v);
@@ -80,54 +41,6 @@ const plClass = (n: number) =>
       ? "text-red-600 dark:text-red-400"
       : "text-muted-foreground";
 
-// --- Helper utilities ---
-const toTimeframe = (v: string): Timeframe =>
-  v === "week" || v === "month" || v === "year" || v === "all" ? v : "all";
-
-const toDate = (val: unknown): Date | undefined => {
-  if (val === null || val === undefined) return undefined;
-  const d = new Date(val as string | number | Date);
-  return Number.isNaN(d.getTime()) ? undefined : d;
-};
-
-const getTradeClosedDate = (t: Trade | TradeLike): Date | undefined => {
-  const tl = t as Partial<TradeLike>;
-  return toDate(tl.closedAt) ?? toDate(tl.updatedAt) ?? toDate(tl.createdAt);
-};
-
-const computePercentPl = (t: Trade | TradeLike): number | null => {
-  const tl = t as Partial<TradeLike>;
-  const direct =
-    typeof tl.percentPL === "number" && !Number.isNaN(tl.percentPL)
-      ? tl.percentPL
-      : null;
-  if (direct !== null) return direct;
-
-  // Fallback: derive from premiumCaptured vs initial premium received (contractPrice * contractsInitial * 100)
-  const premium =
-    typeof tl.premiumCaptured === "number" ? tl.premiumCaptured : null;
-  const cp = typeof tl.contractPrice === "number" ? tl.contractPrice : null;
-  const ci = (tl as TradeLike).contractsInitial;
-  const contractsInitial =
-    typeof ci === "number"
-      ? ci
-      : typeof tl.contracts === "number"
-        ? tl.contracts
-        : null;
-
-  if (
-    premium !== null &&
-    cp !== null &&
-    cp > 0 &&
-    contractsInitial !== null &&
-    contractsInitial > 0
-  ) {
-    const denom = cp * contractsInitial * 100;
-    if (denom > 0) return (premium / denom) * 100;
-  }
-  return null;
-};
-
 const formatUSD = (n: number) =>
   new Intl.NumberFormat("en-US", {
     style: "currency",
@@ -136,317 +49,85 @@ const formatUSD = (n: number) =>
     maximumFractionDigits: 2,
   }).format(n);
 
+const toTimeframe = (v: string): Timeframe =>
+  v === "week" || v === "month" || v === "year" || v === "all" ? v : "all";
 
-const getStockClosedDate = (s: StockLotLike): Date | undefined => {
-  return toDate(s.closedAt) ?? toDate((s as StockLotLike).openedAt);
-};
+function getDateRange(tf: Timeframe): { dateFrom: string | null; dateTo: string | null } {
+  const now = new Date();
+  const dateTo = now.toISOString();
+  if (tf === "all") return { dateFrom: null, dateTo: null };
+  const from = new Date(now);
+  if (tf === "week") from.setDate(from.getDate() - 7);
+  if (tf === "month") from.setMonth(from.getMonth() - 1);
+  if (tf === "year") from.setFullYear(from.getFullYear() - 1);
+  return { dateFrom: from.toISOString(), dateTo };
+}
 
-const computeStockPercentPl = (s: StockLotLike): number | null => {
-  const pnl = toNumber(s.realizedPnl);
-  const avg = toNumber(s.avgCost);
-  const shares = toNumber(s.shares);
-  const basis = avg * shares;
-  if (basis <= 0) return null;
+function computeTradePercentPL(item: Extract<ClosedHistoryItem, { kind: "trade" }>): number | null {
+  if (item.percentPL != null) return item.percentPL;
+  const cp = item.contractPrice;
+  const ci = item.contractsInitial;
+  const pc = item.premiumCaptured;
+  if (pc != null && cp > 0 && ci > 0) {
+    const denom = cp * ci * 100;
+    if (denom > 0) return (pc / denom) * 100;
+  }
+  return null;
+}
+
+function computeStockPercentPL(item: Extract<ClosedHistoryItem, { kind: "stock" }>): number | null {
+  const pnl = item.realizedPnl;
+  const basis = item.avgCost * item.shares;
+  if (pnl == null || basis <= 0) return null;
   return (pnl / basis) * 100;
-};
+}
 
-export function ClosedTradesTable({
-  trades,
-  portfolioId,
-}: {
-  trades: Trade[];
-  portfolioId: string;
-}) {
-  const [sorting, setSorting] = useState<SortingState>([]);
+export function ClosedTradesTable({ portfolioId }: { portfolioId: string }) {
   const router = useRouter();
-
-  const closedStocksKey = `/api/stocks?portfolioId=${encodeURIComponent(
-    portfolioId,
-  )}&status=closed`;
-
-  const { data: closedStocksData } = useSWR<StocksApiResponse>(
-    closedStocksKey,
-    fetcher,
-  );
-
-  const closedStockLots: StockLotLike[] =
-    (closedStocksData?.stockLots ?? closedStocksData?.stocks ?? []) || [];
-
-  // Mobile filters sheet
+  const [timeframe, setTimeframe] = useState<Timeframe>("month");
+  const [pageSize, setPageSize] = useState(25);
+  const [pageIndex, setPageIndex] = useState(0);
   const [filtersOpen, setFiltersOpen] = useState(false);
 
-  // Pagination & Filters
-  const [timeframe, setTimeframe] = useState<"week" | "month" | "year" | "all">(
-    "month",
-  );
-  const [pageSize, setPageSize] = useState<number>(10);
-  const [pageIndex, setPageIndex] = useState<number>(0);
-
-  // Determine start date for selected timeframe
-  function getStartDate(tf: "week" | "month" | "year" | "all") {
-    const now = new Date();
-    const d = new Date(now);
-    if (tf === "week") d.setDate(d.getDate() - 7);
-    if (tf === "month") d.setMonth(d.getMonth() - 1);
-    if (tf === "year") d.setFullYear(d.getFullYear() - 1);
-    return tf === "all" ? null : d;
-  }
-
-  const filteredRows = useMemo(() => {
-    const start = getStartDate(timeframe);
-
-    const tradeRows: ClosedRow[] = trades.map((t) => ({
-      kind: "trade",
-      id: t.id,
-      item: t as TradeLike,
-    }));
-
-    const stockRows: ClosedRow[] = closedStockLots.map((s) => ({
-      kind: "stock",
-      id: s.id,
-      item: s,
-    }));
-
-    const all = [...tradeRows, ...stockRows];
-
-    const withinTimeframe = start
-      ? all.filter((r) => {
-          const d =
-            r.kind === "trade"
-              ? getTradeClosedDate(r.item)
-              : getStockClosedDate(r.item);
-          if (!d) return true;
-          return d >= start;
-        })
-      : all;
-
-    // Sort newest-first by closed date
-    return withinTimeframe.sort((a, b) => {
-      const da =
-        a.kind === "trade"
-          ? getTradeClosedDate(a.item)
-          : getStockClosedDate(a.item);
-      const db =
-        b.kind === "trade"
-          ? getTradeClosedDate(b.item)
-          : getStockClosedDate(b.item);
-      const ta = da ? da.getTime() : 0;
-      const tb = db ? db.getTime() : 0;
-      return tb - ta;
-    });
-  }, [trades, closedStockLots, timeframe]);
-
   // Reset to first page when filters or page size change
-  useEffect(() => {
-    setPageIndex(0);
-  }, [timeframe, pageSize]);
+  useEffect(() => { setPageIndex(0); }, [timeframe, pageSize]);
 
+  const { dateFrom, dateTo } = useMemo(() => getDateRange(timeframe), [timeframe]);
 
-  const columns = useMemo<ColumnDef<ClosedRow>[]>(() => {
-    return [
-      {
-        header: "Ticker",
-        accessorFn: (r) =>
-          r.kind === "trade"
-            ? (r.item as TradeLike).ticker
-            : (r.item as StockLotLike).ticker,
-        cell: ({ row }) => {
-          const r = row.original;
-          const ticker =
-            r.kind === "trade"
-              ? (r.item as TradeLike).ticker
-              : (r.item as StockLotLike).ticker;
-          return <span className="font-semibold">{ticker}</span>;
-        },
-      },
-      {
-        header: "Type",
-        accessorFn: (r) => (r.kind === "trade" ? (r.item as TradeLike).type : "Shares"),
-        cell: ({ row }) => {
-          const r = row.original;
-          return r.kind === "trade"
-            ? <TypeBadge type={String((r.item as TradeLike).type)} />
-            : <span className="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-bold tracking-wide bg-muted text-muted-foreground">Shares</span>;
-        },
-      },
-      {
-        header: "Strike / Cost",
-        accessorFn: (r) =>
-          r.kind === "trade"
-            ? Number((r.item as TradeLike).strikePrice ?? 0)
-            : toNumber((r.item as StockLotLike).avgCost),
-        cell: ({ row }) => {
-          const r = row.original;
-          if (r.kind === "trade") {
-            const strike = Number((r.item as TradeLike).strikePrice ?? 0);
-            return <span className="tabular-nums">{formatUSD(strike)}</span>;
-          }
-          const avg = toNumber((r.item as StockLotLike).avgCost);
-          return (
-            <div>
-              <div className="tabular-nums">{formatUSD(avg)}</div>
-              <div className="text-xs text-muted-foreground">avg cost</div>
-            </div>
-          );
-        },
-        meta: { align: "right" },
-      },
-      {
-        header: "Qty",
-        accessorFn: (r) =>
-          r.kind === "trade"
-            ? ((r.item as TradeLike).contractsInitial ?? (r.item as TradeLike).contracts ?? 0)
-            : toNumber((r.item as StockLotLike).shares),
-        cell: ({ row }) => {
-          const r = row.original;
-          if (r.kind === "trade") {
-            const t = r.item as TradeLike;
-            const qty = t.contractsInitial ?? t.contracts ?? 0;
-            return (
-              <div>
-                <div>{qty}</div>
-                <div className="text-xs text-muted-foreground">contract{qty === 1 ? "" : "s"}</div>
-              </div>
-            );
-          }
-          const shares = toNumber((r.item as StockLotLike).shares);
-          return (
-            <div>
-              <div>{shares}</div>
-              <div className="text-xs text-muted-foreground">shares</div>
-            </div>
-          );
-        },
-        meta: { align: "right" },
-      },
-      {
-        header: "P/L",
-        accessorFn: (r) => {
-          if (r.kind === "trade") return toNumber((r.item as TradeLike).premiumCaptured);
-          return toNumber((r.item as StockLotLike).realizedPnl);
-        },
-        cell: ({ row }) => {
-          const r = row.original;
-          const dollars =
-            r.kind === "trade"
-              ? toNumber((r.item as TradeLike).premiumCaptured)
-              : toNumber((r.item as StockLotLike).realizedPnl);
-          const pct =
-            r.kind === "trade"
-              ? computePercentPl(r.item as TradeLike)
-              : computeStockPercentPl(r.item as StockLotLike);
-          return (
-            <div>
-              <div className={`tabular-nums font-medium ${plClass(dollars)}`}>
-                {formatUSD(dollars)}
-              </div>
-              {pct !== null && (
-                <div className={`text-xs tabular-nums ${plClass(pct)}`}>
-                  {pct >= 0 ? "+" : ""}{pct.toFixed(2)}%
-                </div>
-              )}
-            </div>
-          );
-        },
-        meta: { align: "right" },
-      },
-      {
-        header: "Closed",
-        accessorFn: (r) => {
-          const d =
-            r.kind === "trade"
-              ? getTradeClosedDate(r.item)
-              : getStockClosedDate(r.item as StockLotLike);
-          return d ? d.getTime() : 0;
-        },
-        cell: ({ row }) => {
-          const r = row.original;
-          const d =
-            r.kind === "trade"
-              ? getTradeClosedDate(r.item)
-              : getStockClosedDate(r.item as StockLotLike);
-          return (
-            <span className="text-muted-foreground tabular-nums">
-              {d ? formatDateOnlyUTC(d) : "—"}
-            </span>
-          );
-        },
-      },
-    ];
-  }, []);
+  const skip = pageIndex * pageSize;
+  const swrKey = useMemo(() => {
+    const params = new URLSearchParams({ take: String(pageSize), skip: String(skip) });
+    if (dateFrom) params.set("dateFrom", dateFrom);
+    if (dateTo) params.set("dateTo", dateTo);
+    return `/api/portfolios/${portfolioId}/closed-history?${params}`;
+  }, [portfolioId, pageSize, skip, dateFrom, dateTo]);
 
-  const table = useReactTable({
-    data: filteredRows,
-    columns,
-    state: { sorting },
-    onSortingChange: setSorting,
-    getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-  });
+  const { data, isLoading } = useSWR<ClosedHistoryResponse>(swrKey, fetcher);
 
-  // Table rows after sorting
-  const allRows = table.getRowModel().rows;
-  const totalRows = allRows.length;
-  const pageCount = Math.max(1, Math.ceil(totalRows / pageSize));
-  const start = pageIndex * pageSize;
-  const end = start + pageSize;
-  const pageRows = allRows.slice(start, end);
+  const items = data?.items ?? [];
+  const total = data?.total ?? 0;
+  const pageCount = Math.max(1, Math.ceil(total / pageSize));
 
-  // Metrics (guarded for optional fields)
-  const metrics = useMemo(() => {
-    const originals = allRows.map((r) => r.original as ClosedRow);
-    const count = originals.length;
-
-    const percentVals: number[] = originals
-      .map((r) =>
-        r.kind === "trade"
-          ? computePercentPl(r.item as TradeLike)
-          : computeStockPercentPl(r.item as StockLotLike),
-      )
-      .filter((v): v is number => typeof v === "number" && !Number.isNaN(v));
-    const avgPercentPL = percentVals.length
-      ? percentVals.reduce((a, b) => a + b, 0) / percentVals.length
-      : null;
-
-    const premiumVals: number[] = originals
-      .map((r) => {
-        if (r.kind === "trade") {
-          const t = r.item as TradeLike;
-          return typeof t.premiumCaptured === "number" ? t.premiumCaptured : undefined;
-        }
-        return toNumber((r.item as StockLotLike).realizedPnl);
-      })
-      .filter((v): v is number => typeof v === "number" && !Number.isNaN(v));
-    const totalPremiumCaptured = premiumVals.length
-      ? premiumVals.reduce((a, b) => a + b, 0)
-      : null;
-
-    return { count, avgPercentPL, totalPremiumCaptured };
-  }, [allRows]);
+  const metrics = {
+    count: total,
+    totalPremium: data?.totalPremium ?? null,
+    avgPercentPL: data?.avgPercentPL ?? null,
+  };
 
   return (
     <div className="w-full">
-      {/* Mobile toolbar: Filters + Pagination */}
+      {/* Mobile toolbar */}
       <div className="mb-3 md:hidden px-4 pt-4 flex items-center justify-between">
         <Sheet open={filtersOpen} onOpenChange={setFiltersOpen}>
           <SheetTrigger asChild>
-            <Button variant="outline" size="sm">
-              Filters
-            </Button>
+            <Button variant="outline" size="sm">Filters</Button>
           </SheetTrigger>
           <SheetContent side="bottom" className="p-4">
-            <SheetHeader>
-              <SheetTitle>Closed Trades Filters</SheetTitle>
-            </SheetHeader>
+            <SheetHeader><SheetTitle>Closed Trades Filters</SheetTitle></SheetHeader>
             <div className="mt-3 space-y-3">
               <div className="flex items-center justify-between gap-3">
-                <Label htmlFor="ct-timeframe-mobile" className="text-sm">
-                  Timeframe
-                </Label>
-                <Select
-                  value={timeframe}
-                  onValueChange={(v) => setTimeframe(toTimeframe(v))}
-                >
+                <Label htmlFor="ct-timeframe-mobile" className="text-sm">Timeframe</Label>
+                <Select value={timeframe} onValueChange={(v) => setTimeframe(toTimeframe(v))}>
                   <SelectTrigger id="ct-timeframe-mobile" className="w-40">
                     <SelectValue placeholder="Select timeframe" />
                   </SelectTrigger>
@@ -459,18 +140,12 @@ export function ClosedTradesTable({
                 </Select>
               </div>
               <div className="flex items-center justify-between gap-3">
-                <Label htmlFor="ct-pagesize-mobile" className="text-sm">
-                  Rows
-                </Label>
-                <Select
-                  value={String(pageSize)}
-                  onValueChange={(v) => setPageSize(Number(v))}
-                >
+                <Label htmlFor="ct-pagesize-mobile" className="text-sm">Rows</Label>
+                <Select value={String(pageSize)} onValueChange={(v) => setPageSize(Number(v))}>
                   <SelectTrigger id="ct-pagesize-mobile" className="w-28">
                     <SelectValue placeholder="Rows" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="10">10</SelectItem>
                     <SelectItem value="25">25</SelectItem>
                     <SelectItem value="50">50</SelectItem>
                     <SelectItem value="100">100</SelectItem>
@@ -479,52 +154,24 @@ export function ClosedTradesTable({
               </div>
             </div>
             <SheetFooter className="mt-4 flex items-center justify-end gap-2">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setFiltersOpen(false)}
-              >
-                Close
-              </Button>
+              <Button variant="outline" size="sm" onClick={() => setFiltersOpen(false)}>Close</Button>
             </SheetFooter>
           </SheetContent>
         </Sheet>
 
-        {/* Compact mobile pagination */}
         <div className="flex items-center gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setPageIndex((p) => Math.max(0, p - 1))}
-            disabled={pageIndex === 0}
-          >
-            ‹ Prev
-          </Button>
-          <span className="text-xs text-muted-foreground">
-            {Math.min(pageIndex + 1, pageCount)}/{pageCount}
-          </span>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setPageIndex((p) => Math.min(pageCount - 1, p + 1))}
-            disabled={pageIndex >= pageCount - 1}
-          >
-            Next ›
-          </Button>
+          <Button variant="outline" size="sm" onClick={() => setPageIndex((p) => Math.max(0, p - 1))} disabled={pageIndex === 0 || isLoading}>‹ Prev</Button>
+          <span className="text-xs text-muted-foreground">{Math.min(pageIndex + 1, pageCount)}/{pageCount}</span>
+          <Button variant="outline" size="sm" onClick={() => setPageIndex((p) => Math.min(pageCount - 1, p + 1))} disabled={pageIndex >= pageCount - 1 || isLoading}>Next ›</Button>
         </div>
       </div>
 
-      {/* Controls & Metrics */}
-      <div className="mb-3 px-4 pt-4 hidden md:flex md:flex-row md:items-center md:justify-between">
+      {/* Desktop controls & metrics */}
+      <div className="mb-3 px-4 pt-4 hidden md:flex md:flex-row md:items-center md:justify-between gap-4">
         <div className="flex items-center gap-3">
           <div className="flex items-center gap-2">
-            <Label htmlFor="timeframe" className="text-sm">
-              Timeframe
-            </Label>
-            <Select
-              value={timeframe}
-              onValueChange={(v) => setTimeframe(toTimeframe(v))}
-            >
+            <Label htmlFor="timeframe" className="text-sm">Timeframe</Label>
+            <Select value={timeframe} onValueChange={(v) => setTimeframe(toTimeframe(v))}>
               <SelectTrigger id="timeframe" className="w-44">
                 <SelectValue placeholder="Select timeframe" />
               </SelectTrigger>
@@ -536,20 +183,13 @@ export function ClosedTradesTable({
               </SelectContent>
             </Select>
           </div>
-
           <div className="flex items-center gap-2">
-            <Label htmlFor="pagesize" className="text-sm">
-              Rows per page
-            </Label>
-            <Select
-              value={String(pageSize)}
-              onValueChange={(v) => setPageSize(Number(v))}
-            >
+            <Label htmlFor="pagesize" className="text-sm">Rows per page</Label>
+            <Select value={String(pageSize)} onValueChange={(v) => setPageSize(Number(v))}>
               <SelectTrigger id="pagesize" className="w-28">
                 <SelectValue placeholder="Rows" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="10">10</SelectItem>
                 <SelectItem value="25">25</SelectItem>
                 <SelectItem value="50">50</SelectItem>
                 <SelectItem value="100">100</SelectItem>
@@ -558,247 +198,158 @@ export function ClosedTradesTable({
           </div>
         </div>
 
-        {/* Metrics summary */}
         <div className="flex flex-wrap gap-4 text-sm text-muted-foreground w-full sm:w-auto">
           <div>
-            <div className="uppercase text-[11px] tracking-wide">
-              Closed trades
-            </div>
-            <div className="text-base font-semibold text-foreground">
-              {metrics.count}
-            </div>
+            <div className="uppercase text-[11px] tracking-wide">Closed trades</div>
+            <div className="text-base font-semibold text-foreground">{metrics.count}</div>
           </div>
           <div>
-            <div className="uppercase text-[11px] tracking-wide">
-              Total Premium
-            </div>
+            <div className="uppercase text-[11px] tracking-wide">Total P/L</div>
             <div className="text-base font-semibold text-foreground">
-              {metrics.totalPremiumCaptured !== null
-                ? formatUSD(metrics.totalPremiumCaptured)
-                : "—"}
+              {metrics.totalPremium != null ? formatUSD(metrics.totalPremium) : "—"}
             </div>
           </div>
           <div>
             <div className="uppercase text-[11px] tracking-wide">Avg % P/L</div>
             <div className="text-base font-semibold text-foreground">
-              {metrics.avgPercentPL !== null
-                ? `${Number(metrics.avgPercentPL).toFixed(2)}%`
-                : "—"}
+              {metrics.avgPercentPL != null ? `${Number(metrics.avgPercentPL).toFixed(2)}%` : "—"}
             </div>
           </div>
         </div>
       </div>
 
       <div className="w-full overflow-x-auto">
-        {/* Mobile cards (shown on <md) */}
-        <div className="md:hidden space-y-2">
-          {pageRows.length === 0 ? (
-            <div className="rounded border p-3 text-center text-sm text-muted-foreground">
-              No trades or stock lots have been closed yet.
-            </div>
-          ) : (
-            pageRows.map((row) => {
-              const r = row.original as ClosedRow;
+        {isLoading ? (
+          <div className="flex items-center justify-center py-12 text-muted-foreground gap-2">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            <span className="text-sm">Loading…</span>
+          </div>
+        ) : items.length === 0 ? (
+          <div className="px-4 py-8 text-center text-sm text-muted-foreground">No closed trades yet.</div>
+        ) : (
+          <>
+            {/* Mobile cards */}
+            <div className="md:hidden space-y-2">
+              {items.map((item) => {
+                const isStock = item.kind === "stock";
+                const pnl = isStock
+                  ? toNumber((item as Extract<ClosedHistoryItem, { kind: "stock" }>).realizedPnl)
+                  : toNumber((item as Extract<ClosedHistoryItem, { kind: "trade" }>).premiumCaptured);
+                const pct = isStock
+                  ? computeStockPercentPL(item as Extract<ClosedHistoryItem, { kind: "stock" }>)
+                  : computeTradePercentPL(item as Extract<ClosedHistoryItem, { kind: "trade" }>);
+                const closedDate = new Date(item.closedAt);
+                const href = isStock
+                  ? `/portfolios/${portfolioId}/stocks/${item.id}`
+                  : `/portfolios/${portfolioId}/trades/${item.id}`;
 
-              const ticker =
-                r.kind === "trade"
-                  ? (r.item as TradeLike).ticker
-                  : (r.item as StockLotLike).ticker;
-
-              const closedDate =
-                r.kind === "trade"
-                  ? getTradeClosedDate(r.item as TradeLike)
-                  : getStockClosedDate(r.item as StockLotLike);
-
-              const premium =
-                r.kind === "trade"
-                  ? typeof (r.item as TradeLike).premiumCaptured === "number"
-                    ? formatUSD((r.item as TradeLike).premiumCaptured as number)
-                    : "—"
-                  : formatUSD(toNumber((r.item as StockLotLike).realizedPnl));
-
-              const pct =
-                r.kind === "trade"
-                  ? computePercentPl(r.item as TradeLike)
-                  : computeStockPercentPl(r.item as StockLotLike);
-
-              const pctLabel = pct !== null ? `${pct.toFixed(2)}%` : "—";
-
-              return (
-                <button
-                  key={`${r.kind}-${r.id}`}
-                  onClick={() =>
-                    router.push(
-                      r.kind === "trade"
-                        ? `/portfolios/${portfolioId}/trades/${r.id}`
-                        : `/portfolios/${portfolioId}/stocks/${r.id}`,
-                    )
-                  }
-                  className="w-full text-left rounded-xl border p-3 bg-card hover:bg-accent transition"
-                >
-                  <div className="flex items-center justify-between">
-                    <div className="font-semibold">{ticker}</div>
-                    {r.kind === "trade"
-                      ? <TypeBadge type={String((r.item as TradeLike).type)} />
-                      : <span className="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-bold tracking-wide bg-muted text-muted-foreground">Shares</span>
-                    }
-                  </div>
-                  <div className="mt-2 grid grid-cols-2 gap-2 text-sm">
-                    <div>
-                      <div className="text-xs text-muted-foreground">Closed</div>
-                      <div>{closedDate ? formatDateOnlyUTC(closedDate) : "—"}</div>
+                return (
+                  <button key={`${item.kind}-${item.id}`} onClick={() => router.push(href)}
+                    className="w-full text-left rounded-xl border p-3 bg-card hover:bg-accent transition">
+                    <div className="flex items-center justify-between">
+                      <div className="font-semibold">{item.ticker}</div>
+                      {isStock
+                        ? <span className="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-bold tracking-wide bg-muted text-muted-foreground">Shares</span>
+                        : <TypeBadge type={(item as Extract<ClosedHistoryItem, { kind: "trade" }>).type} />}
                     </div>
-                    <div>
-                      <div className="text-xs text-muted-foreground">P/L</div>
-                      <div className={`font-medium ${plClass(r.kind === "trade" ? toNumber((r.item as TradeLike).premiumCaptured) : toNumber((r.item as StockLotLike).realizedPnl))}`}>
-                        {premium}
-                      </div>
-                      {pct !== null && (
-                        <div className={`text-xs ${plClass(pct)}`}>
-                          {pct >= 0 ? "+" : ""}{pctLabel}
-                        </div>
-                      )}
-                    </div>
-                    <div>
-                      <div className="text-xs text-muted-foreground">
-                        {r.kind === "trade" ? "Strike" : "Avg Cost"}
-                      </div>
-                      <div className="tabular-nums">
-                        {r.kind === "trade"
-                          ? formatUSD(Number((r.item as TradeLike).strikePrice ?? 0))
-                          : formatUSD(toNumber((r.item as StockLotLike).avgCost))}
-                      </div>
-                    </div>
-                    <div>
-                      <div className="text-xs text-muted-foreground">
-                        {r.kind === "trade" ? "Contracts" : "Shares"}
+                    <div className="mt-2 grid grid-cols-2 gap-2 text-sm">
+                      <div>
+                        <div className="text-xs text-muted-foreground">Closed</div>
+                        <div>{formatDateOnlyUTC(closedDate)}</div>
                       </div>
                       <div>
-                        {r.kind === "trade"
-                          ? ((r.item as TradeLike).contractsInitial ?? (r.item as TradeLike).contracts ?? 0)
-                          : toNumber((r.item as StockLotLike).shares)}
+                        <div className="text-xs text-muted-foreground">P/L</div>
+                        <div className={`font-medium ${plClass(pnl)}`}>{formatUSD(pnl)}</div>
+                        {pct != null && <div className={`text-xs ${plClass(pct)}`}>{pct >= 0 ? "+" : ""}{pct.toFixed(2)}%</div>}
+                      </div>
+                      <div>
+                        <div className="text-xs text-muted-foreground">{isStock ? "Avg Cost" : "Strike"}</div>
+                        <div className="tabular-nums">
+                          {isStock
+                            ? formatUSD(toNumber((item as Extract<ClosedHistoryItem, { kind: "stock" }>).avgCost))
+                            : formatUSD((item as Extract<ClosedHistoryItem, { kind: "trade" }>).strikePrice)}
+                        </div>
+                      </div>
+                      <div>
+                        <div className="text-xs text-muted-foreground">{isStock ? "Shares" : "Contracts"}</div>
+                        <div>{isStock
+                          ? (item as Extract<ClosedHistoryItem, { kind: "stock" }>).shares
+                          : (item as Extract<ClosedHistoryItem, { kind: "trade" }>).contractsInitial}
+                        </div>
                       </div>
                     </div>
-                  </div>
-                </button>
-              );
-            })
-          )}
-        </div>
+                  </button>
+                );
+              })}
+            </div>
 
-        {/* Desktop table (shown on md+) */}
-        <div className="hidden md:block">
-          <table className="min-w-full text-sm text-left text-foreground">
-            <thead className="border-b border-border/60">
-              {table.getHeaderGroups().map((headerGroup) => (
-                <tr key={headerGroup.id}>
-                  {headerGroup.headers.map((header) => (
-                    <th
-                      key={header.id}
-                      className={
-                        header.column.getCanSort()
-                          ? "px-4 py-2.5 text-[11px] font-medium text-muted-foreground uppercase tracking-wide cursor-pointer select-none"
-                          : "px-4 py-2.5 text-[11px] font-medium text-muted-foreground uppercase tracking-wide select-none"
-                      }
-                      onClick={
-                        header.column.getCanSort()
-                          ? header.column.getToggleSortingHandler()
-                          : undefined
-                      }
-                    >
-                      <div className="flex items-center gap-1">
-                        {flexRender(header.column.columnDef.header, header.getContext())}
-                        {header.column.getCanSort() && (
-                          <span className="text-[10px] text-muted-foreground">
-                            {header.column.getIsSorted() === "asc" && "▲"}
-                            {header.column.getIsSorted() === "desc" && "▼"}
-                          </span>
-                        )}
-                      </div>
-                    </th>
-                  ))}
-                </tr>
-              ))}
-            </thead>
-            <tbody>
-              {pageRows.length === 0 ? (
-                <tr>
-                  <td
-                    colSpan={table.getAllColumns().length}
-                    className="px-4 py-6 text-center text-muted-foreground"
-                  >
-                    No trades or stock lots have been closed yet.
-                  </td>
-                </tr>
-              ) : (
-                pageRows.map((row) => (
-                  <tr
-                    key={row.id}
-                    className="group border-b border-border/40 last:border-0 hover:bg-muted/40 transition-colors cursor-pointer"
-                    onClick={() => {
-                      const r = row.original as ClosedRow;
-                      router.push(
-                        r.kind === "trade"
-                          ? `/portfolios/${portfolioId}/trades/${r.id}`
-                          : `/portfolios/${portfolioId}/stocks/${r.id}`,
-                      );
-                    }}
-                  >
-                    {row.getVisibleCells().map((cell) => (
-                      <td key={cell.id} className="px-4 py-2">
-                        {flexRender(
-                          cell.column.columnDef.cell,
-                          cell.getContext(),
-                        )}
-                      </td>
+            {/* Desktop table */}
+            <div className="hidden md:block">
+              <table className="min-w-full text-sm text-left text-foreground">
+                <thead className="border-b border-border/60">
+                  <tr>
+                    {["Ticker", "Type", "Strike / Cost", "Qty", "P/L", "Closed"].map((h) => (
+                      <th key={h} className="px-4 py-2.5 text-[11px] font-medium text-muted-foreground uppercase tracking-wide">{h}</th>
                     ))}
                   </tr>
-                ))
-              )}
-            </tbody>
-          </table>
-        </div>
+                </thead>
+                <tbody>
+                  {items.map((item) => {
+                    const isStock = item.kind === "stock";
+                    const trade = item as Extract<ClosedHistoryItem, { kind: "trade" }>;
+                    const stock = item as Extract<ClosedHistoryItem, { kind: "stock" }>;
+                    const pnl = isStock ? toNumber(stock.realizedPnl) : toNumber(trade.premiumCaptured);
+                    const pct = isStock ? computeStockPercentPL(stock) : computeTradePercentPL(trade);
+                    const closedDate = new Date(item.closedAt);
+                    const href = isStock
+                      ? `/portfolios/${portfolioId}/stocks/${item.id}`
+                      : `/portfolios/${portfolioId}/trades/${item.id}`;
+
+                    return (
+                      <tr key={`${item.kind}-${item.id}`}
+                        className="border-b border-border/40 last:border-0 hover:bg-muted/40 transition-colors cursor-pointer"
+                        onClick={() => router.push(href)}>
+                        <td className="px-4 py-2"><span className="font-semibold">{item.ticker}</span></td>
+                        <td className="px-4 py-2">
+                          {isStock
+                            ? <span className="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-bold tracking-wide bg-muted text-muted-foreground">Shares</span>
+                            : <TypeBadge type={trade.type} />}
+                        </td>
+                        <td className="px-4 py-2 tabular-nums">
+                          {isStock
+                            ? <div><div>{formatUSD(stock.avgCost)}</div><div className="text-xs text-muted-foreground">avg cost</div></div>
+                            : formatUSD(trade.strikePrice)}
+                        </td>
+                        <td className="px-4 py-2">
+                          {isStock
+                            ? <div><div>{stock.shares}</div><div className="text-xs text-muted-foreground">shares</div></div>
+                            : <div><div>{trade.contractsInitial}</div><div className="text-xs text-muted-foreground">contract{trade.contractsInitial === 1 ? "" : "s"}</div></div>}
+                        </td>
+                        <td className="px-4 py-2">
+                          <div className={`tabular-nums font-medium ${plClass(pnl)}`}>{formatUSD(pnl)}</div>
+                          {pct != null && <div className={`text-xs tabular-nums ${plClass(pct)}`}>{pct >= 0 ? "+" : ""}{pct.toFixed(2)}%</div>}
+                        </td>
+                        <td className="px-4 py-2 text-muted-foreground tabular-nums">{formatDateOnlyUTC(closedDate)}</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </>
+        )}
       </div>
 
       {/* Pagination footer */}
       <div className="mt-3 px-4 pb-4 hidden md:flex items-center justify-between">
         <div className="text-xs text-gray-600 dark:text-gray-400">
-          Page {Math.min(pageIndex + 1, pageCount)} of {pageCount} • {totalRows}{" "}
-          result{totalRows === 1 ? "" : "s"}
+          Page {Math.min(pageIndex + 1, pageCount)} of {pageCount} • {total} result{total === 1 ? "" : "s"}
         </div>
         <div className="flex items-center gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setPageIndex(0)}
-            disabled={pageIndex === 0}
-          >
-            « First
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setPageIndex((p) => Math.max(0, p - 1))}
-            disabled={pageIndex === 0}
-          >
-            ‹ Prev
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setPageIndex((p) => Math.min(pageCount - 1, p + 1))}
-            disabled={pageIndex >= pageCount - 1}
-          >
-            Next ›
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setPageIndex(pageCount - 1)}
-            disabled={pageIndex >= pageCount - 1}
-          >
-            Last »
-          </Button>
+          <Button variant="outline" size="sm" onClick={() => setPageIndex(0)} disabled={pageIndex === 0 || isLoading}>« First</Button>
+          <Button variant="outline" size="sm" onClick={() => setPageIndex((p) => Math.max(0, p - 1))} disabled={pageIndex === 0 || isLoading}>‹ Prev</Button>
+          <Button variant="outline" size="sm" onClick={() => setPageIndex((p) => Math.min(pageCount - 1, p + 1))} disabled={pageIndex >= pageCount - 1 || isLoading}>Next ›</Button>
+          <Button variant="outline" size="sm" onClick={() => setPageIndex(pageCount - 1)} disabled={pageIndex >= pageCount - 1 || isLoading}>Last »</Button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
- Add @@index([portfolioId, status, closedAt]) on Trade and @@index([portfolioId, closedAt]) on StockLot for date-range queries
- New GET /api/portfolios/[id]/closed-history: server-paginated, date-filtered combined trades+stock lots with aggregate metrics
- PortfolioDetail drops unbounded useTrades(id,'closed') fetch; ClosedTradesTable self-fetches with SWR key encoding timeframe+page
- Fix /api/reports/closed N+1: replace per-portfolio queries with single trade.findMany({ portfolioId: { in: [...] } })
- Add explicit select clauses to /api/trades and /api/stocks GET to trim wire payload ~25-35%
- Update closed.test.ts to reflect consolidated query shape (256 tests)